### PR TITLE
Add allowGuestLocalWorkspace config flag

### DIFF
--- a/.docker/selfhost/schema.json
+++ b/.docker/selfhost/schema.json
@@ -592,6 +592,11 @@
           "type": "boolean",
           "description": "Allow guests to access demo workspace.\n@default true",
           "default": true
+        },
+        "allowGuestLocalWorkspace": {
+          "type": "boolean",
+          "description": "Allow guests to use local workspace.\n@default true",
+          "default": true
         }
       }
     },

--- a/packages/backend/server/src/core/config/resolver.ts
+++ b/packages/backend/server/src/core/config/resolver.ts
@@ -87,6 +87,8 @@ export class ServerConfigResolver {
       features: this.server.features,
       allowGuestDemoWorkspace:
         this.config.client?.allowGuestDemoWorkspace ?? true,
+      allowGuestLocalWorkspace:
+        this.config.client?.allowGuestLocalWorkspace ?? true,
     };
   }
 

--- a/packages/backend/server/src/core/config/types.ts
+++ b/packages/backend/server/src/core/config/types.ts
@@ -44,4 +44,10 @@ export class ServerConfigType {
     nullable: true,
   })
   allowGuestDemoWorkspace?: boolean | null;
+
+  @Field(() => Boolean, {
+    description: 'allow guests to use local workspace',
+    nullable: true,
+  })
+  allowGuestLocalWorkspace?: boolean | null;
 }

--- a/packages/backend/server/src/core/version/config.ts
+++ b/packages/backend/server/src/core/version/config.ts
@@ -6,6 +6,7 @@ export interface VersionConfig {
     requiredVersion: string;
   };
   allowGuestDemoWorkspace?: boolean;
+  allowGuestLocalWorkspace?: boolean;
 }
 
 declare global {
@@ -31,6 +32,10 @@ defineModuleConfig('client', {
   },
   allowGuestDemoWorkspace: {
     desc: 'Allow guests to access demo workspace.',
+    default: true,
+  },
+  allowGuestLocalWorkspace: {
+    desc: 'Allow guests to use local workspace.',
     default: true,
   },
 });

--- a/packages/backend/server/src/schema.gql
+++ b/packages/backend/server/src/schema.gql
@@ -1571,6 +1571,8 @@ enum SearchTable {
 type ServerConfigType {
   """allow guests to access demo workspace"""
   allowGuestDemoWorkspace: Boolean
+  """allow guests to use local workspace"""
+  allowGuestLocalWorkspace: Boolean
 
   """fetch latest available upgradable release of server"""
   availableUpgrade: ReleaseVersionType

--- a/packages/common/graphql/src/graphql/admin/admin-server-config.gql
+++ b/packages/common/graphql/src/graphql/admin/admin-server-config.gql
@@ -8,6 +8,7 @@ query adminServerConfig {
     name
     features
     allowGuestDemoWorkspace
+    allowGuestLocalWorkspace
     type
     initialized
     credentialsRequirement {

--- a/packages/common/graphql/src/graphql/index.ts
+++ b/packages/common/graphql/src/graphql/index.ts
@@ -33,6 +33,7 @@ export const adminServerConfigQuery = {
     name
     features
     allowGuestDemoWorkspace
+    allowGuestLocalWorkspace
     type
     initialized
     credentialsRequirement {
@@ -1704,6 +1705,7 @@ export const serverConfigQuery = {
     name
     features
     allowGuestDemoWorkspace
+    allowGuestLocalWorkspace
     type
     initialized
     credentialsRequirement {

--- a/packages/common/graphql/src/graphql/server-config.gql
+++ b/packages/common/graphql/src/graphql/server-config.gql
@@ -8,6 +8,7 @@ query serverConfig {
     name
     features
     allowGuestDemoWorkspace
+    allowGuestLocalWorkspace
     type
     initialized
     credentialsRequirement {

--- a/packages/common/graphql/src/schema.ts
+++ b/packages/common/graphql/src/schema.ts
@@ -2152,6 +2152,8 @@ export interface ServerConfigType {
   features: Array<ServerFeature>;
   /** allow guests to access demo workspace */
   allowGuestDemoWorkspace: Scalars['Boolean']['output'];
+  /** allow guests to use local workspace */
+  allowGuestLocalWorkspace: Scalars['Boolean']['output'];
   /** whether server has been initialized */
   initialized: Scalars['Boolean']['output'];
   /** server identical name could be shown as badge on user interface */
@@ -2711,6 +2713,7 @@ export type AdminServerConfigQuery = {
     name: string;
     features: Array<ServerFeature>;
     allowGuestDemoWorkspace: boolean;
+    allowGuestLocalWorkspace: boolean;
     type: ServerDeploymentType;
     initialized: boolean;
     availableUserFeatures: Array<FeatureType>;
@@ -4655,6 +4658,7 @@ export type ServerConfigQuery = {
     name: string;
     features: Array<ServerFeature>;
     allowGuestDemoWorkspace: boolean;
+    allowGuestLocalWorkspace: boolean;
     type: ServerDeploymentType;
     initialized: boolean;
     credentialsRequirement: {

--- a/packages/frontend/admin/src/config.json
+++ b/packages/frontend/admin/src/config.json
@@ -207,6 +207,10 @@
     "allowGuestDemoWorkspace": {
       "type": "Boolean",
       "desc": "Allow guests to access demo workspace."
+    },
+    "allowGuestLocalWorkspace": {
+      "type": "Boolean",
+      "desc": "Allow guests to use local workspace."
     }
   },
   "captcha": {

--- a/packages/frontend/core/src/components/hooks/affine/__tests__/use-sign-out.spec.ts
+++ b/packages/frontend/core/src/components/hooks/affine/__tests__/use-sign-out.spec.ts
@@ -10,6 +10,7 @@ const signOutFn = vi.fn();
 const jumpToIndex = vi.fn();
 const jumpToSignIn = vi.fn();
 let allowGuestDemo = true;
+let allowGuestLocal = false;
 
 vi.mock('@affine/core/modules/cloud', () => ({
   AuthService: class {},
@@ -26,6 +27,9 @@ vi.mock('@toeverything/infra', () => {
             value: {
               get allowGuestDemoWorkspace() {
                 return allowGuestDemo;
+              },
+              get allowGuestLocalWorkspace() {
+                return allowGuestLocal;
               },
             },
           },
@@ -61,6 +65,7 @@ describe('useSignOut', () => {
     signOutFn.mockClear();
     jumpToIndex.mockClear();
     jumpToSignIn.mockClear();
+    allowGuestLocal = false;
   });
 
   test('redirects to index when guest demo allowed', async () => {
@@ -72,8 +77,19 @@ describe('useSignOut', () => {
     expect(jumpToSignIn).not.toHaveBeenCalled();
   });
 
+  test('redirects to index when local workspace allowed', async () => {
+    allowGuestDemo = false;
+    allowGuestLocal = true;
+    const { result } = renderHook(() => useSignOut());
+    result.current();
+    await waitFor(() => expect(signOutFn).toHaveBeenCalled());
+    expect(jumpToIndex).toHaveBeenCalled();
+    expect(jumpToSignIn).not.toHaveBeenCalled();
+  });
+
   test('redirects to sign in when guest demo disabled', async () => {
     allowGuestDemo = false;
+    allowGuestLocal = false;
     const { result } = renderHook(() => useSignOut());
     result.current();
     await waitFor(() => expect(signOutFn).toHaveBeenCalled());

--- a/packages/frontend/core/src/components/hooks/affine/use-sign-out.ts
+++ b/packages/frontend/core/src/components/hooks/affine/use-sign-out.ts
@@ -34,7 +34,8 @@ export const useSignOut = ({
     onConfirm?.()?.catch(console.error);
     try {
       await authService.signOut();
-      if (defaultServerService.server.config$.value.allowGuestDemoWorkspace) {
+      const config = defaultServerService.server.config$.value;
+      if (config.allowGuestDemoWorkspace || config.allowGuestLocalWorkspace) {
         jumpToIndex();
       } else {
         jumpToSignIn();

--- a/packages/frontend/core/src/desktop/pages/index/index.tsx
+++ b/packages/frontend/core/src/desktop/pages/index/index.tsx
@@ -58,6 +58,12 @@ export const Component = ({
         c => c.allowGuestDemoWorkspace
       )
     ) ?? true;
+  const allowGuestLocal =
+    useLiveData(
+      defaultServerService.server.config$.selector(
+        c => c.allowGuestLocalWorkspace
+      )
+    ) ?? BUILD_CONFIG.isElectron;
 
   const workspacesService = useService(WorkspacesService);
   const list = useLiveData(workspacesService.list.workspaces$);
@@ -92,7 +98,7 @@ export const Component = ({
       return;
     }
 
-    if (!allowGuestDemo && !loggedIn) {
+    if (!allowGuestDemo && !allowGuestLocal && !loggedIn) {
       localStorage.removeItem('last_workspace_id');
       jumpToSignIn();
       return;
@@ -126,6 +132,7 @@ export const Component = ({
     }
   }, [
     allowGuestDemo,
+    allowGuestLocal,
     createCloudWorkspace,
     list,
     openPage,
@@ -147,7 +154,7 @@ export const Component = ({
     if (listIsLoading || list.length > 0) {
       return;
     }
-    if (!allowGuestDemo && !loggedIn) {
+    if (!allowGuestDemo && !allowGuestLocal && !loggedIn) {
       localStorage.removeItem('last_workspace_id');
       jumpToSignIn();
       return;
@@ -178,6 +185,7 @@ export const Component = ({
     openPage,
     workspacesService,
     allowGuestDemo,
+    allowGuestLocal,
     loggedIn,
     listIsLoading,
     list,

--- a/packages/frontend/core/src/modules/cloud/constant.ts
+++ b/packages/frontend/core/src/modules/cloud/constant.ts
@@ -27,6 +27,7 @@ export const BUILD_IN_SERVERS: (ServerMetadata & { config: ServerConfig })[] =
               },
             },
             allowGuestDemoWorkspace: true,
+            allowGuestLocalWorkspace: true,
           },
         },
       ]
@@ -54,6 +55,7 @@ export const BUILD_IN_SERVERS: (ServerMetadata & { config: ServerConfig })[] =
                 },
               },
               allowGuestDemoWorkspace: true,
+              allowGuestLocalWorkspace: true,
             },
           },
         ]
@@ -79,6 +81,7 @@ export const BUILD_IN_SERVERS: (ServerMetadata & { config: ServerConfig })[] =
                   },
                 },
                 allowGuestDemoWorkspace: true,
+                allowGuestLocalWorkspace: true,
               },
             },
           ]
@@ -104,6 +107,7 @@ export const BUILD_IN_SERVERS: (ServerMetadata & { config: ServerConfig })[] =
                     },
                   },
                   allowGuestDemoWorkspace: true,
+                  allowGuestLocalWorkspace: true,
                 },
               },
             ]
@@ -129,6 +133,7 @@ export const BUILD_IN_SERVERS: (ServerMetadata & { config: ServerConfig })[] =
                       },
                     },
                     allowGuestDemoWorkspace: true,
+                    allowGuestLocalWorkspace: true,
                   },
                 },
               ]
@@ -154,6 +159,7 @@ export const BUILD_IN_SERVERS: (ServerMetadata & { config: ServerConfig })[] =
                         },
                       },
                       allowGuestDemoWorkspace: true,
+                      allowGuestLocalWorkspace: true,
                     },
                   },
                 ]

--- a/packages/frontend/core/src/modules/cloud/entities/server.ts
+++ b/packages/frontend/core/src/modules/cloud/entities/server.ts
@@ -83,6 +83,7 @@ export class Server extends Entity<{
             features: config.features,
             oauthProviders: config.oauthProviders,
             allowGuestDemoWorkspace: config.allowGuestDemoWorkspace,
+            allowGuestLocalWorkspace: config.allowGuestLocalWorkspace,
             serverName: config.name,
             type: config.type,
             version: config.version,

--- a/packages/frontend/core/src/modules/cloud/services/servers.ts
+++ b/packages/frontend/core/src/modules/cloud/services/servers.ts
@@ -83,6 +83,7 @@ export class ServersService extends Service {
         features: config.features,
         oauthProviders: config.oauthProviders,
         allowGuestDemoWorkspace: config.allowGuestDemoWorkspace,
+        allowGuestLocalWorkspace: config.allowGuestLocalWorkspace,
         serverName: config.name,
         type: config.type,
         initialized: config.initialized,

--- a/packages/frontend/core/src/modules/cloud/types.ts
+++ b/packages/frontend/core/src/modules/cloud/types.ts
@@ -15,6 +15,7 @@ export interface ServerConfig {
   serverName: string;
   features: ServerFeature[];
   allowGuestDemoWorkspace: boolean;
+  allowGuestLocalWorkspace: boolean;
   oauthProviders: OAuthProviderType[];
   type: ServerDeploymentType;
   initialized?: boolean;


### PR DESCRIPTION
## Summary
- add backend server config `allowGuestLocalWorkspace`
- expose it via GraphQL and admin config
- include flag in built‑in server constants and types
- update sign-out behaviour and index page to respect the new flag
- extend unit tests for `use-sign-out`

## Testing
- `yarn install --immutable` *(fails: missing deps / environment issues)*
- `yarn test packages/frontend/core/src/components/hooks/affine/__tests__/use-sign-out.spec.ts` *(fails: couldn't run due to missing deps)*

------
https://chatgpt.com/codex/tasks/task_e_684961592f0c83328b478ae4aec8fba1