### PR TITLE
Fix dynamic selection in group menus

### DIFF
--- a/blocksuite/affine/data-view/src/core/group-by/setting.ts
+++ b/blocksuite/affine/data-view/src/core/group-by/setting.ts
@@ -401,54 +401,58 @@ export const popGroupSetting = (
           ? [
               menu.group({
                 items: [
-                  menu.subMenu({
-                    name: 'Date by',
-                    openOnHover: false,
-                    middleware: dropdownSubMenuMiddleware,
-                    autoHeight: true,
-                    postfix: html`
-                      <div
-                        style="display:flex;align-items:center;gap:4px;font-size:14px;line-height:20px;color:var(--affine-text-secondary-color);margin-left:30px;"
-                      >
-                        ${dateModeLabel(group.groupInfo$.value?.config.name)}
-                      </div>
-                    `,
-                    options: {
-                      items: (
-                        [
-                          ['Relative', 'date-relative'],
-                          ['Day', 'date-day'],
-                          [
-                            'Week',
-                            group.groupInfo$.value?.config.name ===
-                            'date-week-mon'
-                              ? 'date-week-mon'
-                              : 'date-week-sun',
-                          ],
-                          ['Month', 'date-month'],
-                          ['Year', 'date-year'],
-                        ] as [string, string][]
-                      ).map(
-                        ([label, key]): MenuConfig =>
-                          menu.action({
-                            name: label,
-                            label: () => {
-                              const isSelected =
-                                group.groupInfo$.value?.config.name === key;
-                              return html`<span
-                                style="font-size:14px;color:${isSelected
-                                  ? 'var(--affine-text-emphasis-color)'
-                                  : 'var(--affine-text-secondary-color)'}"
-                                >${label}</span
-                              >`;
-                            },
-                            isSelected:
-                              group.groupInfo$.value?.config.name === key,
-                            select: () => group.changeGroupMode(key),
-                          })
-                      ),
-                    },
-                  }),
+                  menu.dynamic(() => [
+                    menu.subMenu({
+                      name: 'Date by',
+                      openOnHover: false,
+                      middleware: dropdownSubMenuMiddleware,
+                      autoHeight: true,
+                      postfix: html`
+                        <div
+                          style="display:flex;align-items:center;gap:4px;font-size:14px;line-height:20px;color:var(--affine-text-secondary-color);margin-left:30px;"
+                        >
+                          ${dateModeLabel(group.groupInfo$.value?.config.name)}
+                        </div>
+                      `,
+                      options: {
+                        items: [
+                          menu.dynamic(() =>
+                            (
+                              [
+                                ['Relative', 'date-relative'],
+                                ['Day', 'date-day'],
+                                [
+                                  'Week',
+                                  group.groupInfo$.value?.config.name === 'date-week-mon'
+                                    ? 'date-week-mon'
+                                    : 'date-week-sun',
+                                ],
+                                ['Month', 'date-month'],
+                                ['Year', 'date-year'],
+                              ] as [string, string][]
+                            ).map(([label, key]): MenuConfig =>
+                              menu.action({
+                                name: label,
+                                label: () => {
+                                  const isSelected =
+                                    group.groupInfo$.value?.config.name === key;
+                                  return html`<span
+                                    style="font-size:14px;color:${isSelected
+                                      ? 'var(--affine-text-emphasis-color)'
+                                      : 'var(--affine-text-secondary-color)'}"
+                                    >${label}</span
+                                  >`;
+                                },
+                                isSelected:
+                                  group.groupInfo$.value?.config.name === key,
+                                select: () => group.changeGroupMode(key),
+                              })
+                            )
+                          ),
+                        ],
+                      },
+                    }),
+                  ]),
                 ],
               }),
 
@@ -456,116 +460,109 @@ export const popGroupSetting = (
                 ? [
                     menu.group({
                       items: [
-                        menu.subMenu({
-                          name: 'Start week on',
-                          postfix: html`
-                            <div
-                              style="display:flex;align-items:center;gap:4px;font-size:14px;line-height:20px;color:var(--affine-text-secondary-color);margin-left:8px;"
-                            >
-                              ${group.groupInfo$.value?.config.name ===
-                              'date-week-mon'
-                                ? 'Monday'
-                                : 'Sunday'}
-                            </div>
-                          `,
-                          options: {
-                            items: [
-                              menu.action({
-                                name: 'Monday',
-                                label: () => {
-                                  const isSelected =
-                                    group.groupInfo$.value?.config.name ===
-                                    'date-week-mon';
-                                  return html`<span
-                                    style="font-size:14px;color:${isSelected
-                                      ? 'var(--affine-text-emphasis-color)'
-                                      : 'var(--affine-text-secondary-color)'}"
-                                    >Monday</span
-                                  >`;
-                                },
-                                isSelected:
-                                  group.groupInfo$.value?.config.name ===
-                                  'date-week-mon',
-                                select: () =>
-                                  group.changeGroupMode('date-week-mon'),
-                              }),
-                              menu.action({
-                                name: 'Sunday',
-                                label: () => {
-                                  const isSelected =
-                                    group.groupInfo$.value?.config.name ===
-                                    'date-week-sun';
-                                  return html`<span
-                                    style="font-size:14px;color:${isSelected
-                                      ? 'var(--affine-text-emphasis-color)'
-                                      : 'var(--affine-text-secondary-color)'}"
-                                    >Sunday</span
-                                  >`;
-                                },
-                                isSelected:
-                                  group.groupInfo$.value?.config.name ===
-                                  'date-week-sun',
-                                select: () =>
-                                  group.changeGroupMode('date-week-sun'),
-                              }),
-                            ],
-                          },
-                        }),
+                        menu.dynamic(() => [
+                          menu.subMenu({
+                            name: 'Start week on',
+                            postfix: html`
+                              <div
+                                style="display:flex;align-items:center;gap:4px;font-size:14px;line-height:20px;color:var(--affine-text-secondary-color);margin-left:8px;"
+                              >
+                                ${group.groupInfo$.value?.config.name ===
+                                'date-week-mon'
+                                  ? 'Monday'
+                                  : 'Sunday'}
+                              </div>
+                            `,
+                            options: {
+                              items: [
+                                menu.dynamic(() =>
+                                  (
+                                    [
+                                      ['Monday', 'date-week-mon'],
+                                      ['Sunday', 'date-week-sun'],
+                                    ] as [string, string][]
+                                  ).map(([label, key]) =>
+                                    menu.action({
+                                      name: label,
+                                      label: () => {
+                                        const isSelected =
+                                          group.groupInfo$.value?.config.name === key;
+                                        return html`<span
+                                          style="font-size:14px;color:${isSelected
+                                            ? 'var(--affine-text-emphasis-color)'
+                                            : 'var(--affine-text-secondary-color)'}"
+                                          >${label}</span
+                                        >`;
+                                      },
+                                      isSelected:
+                                        group.groupInfo$.value?.config.name === key,
+                                      select: () => group.changeGroupMode(key),
+                                    })
+                                  )
+                                ),
+                              ],
+                            },
+                          }),
+                        ]),
                       ],
                     }),
                   ]
                 : []),
-              menu.group({
-                items: [
-                  menu.subMenu({
-                    name: 'Sort',
-                    openOnHover: false,
-                    middleware: dropdownSubMenuMiddleware,
-                    autoHeight: true,
-                    postfix: html`
-                      <div
-                        style="display:flex;align-items:center;gap:4px;font-size:14px;line-height:20px;color:var(--affine-text-secondary-color);margin-left:8px;"
-                      >
-                        ${group.sortAsc$.value
-                          ? 'Oldest first'
-                          : 'Newest first'}
-                      </div>
-                    `,
-                    options: {
-                      items: [
-                        menu.action({
-                          name: 'Oldest first',
-                          label: () => {
-                            const isSelected = group.sortAsc$.value;
-                            return html`<span
-                              style="font-size:14px;color:${isSelected
-                                ? 'var(--affine-text-emphasis-color)'
-                                : 'var(--affine-text-secondary-color)'}"
-                              >Oldest first</span
-                            >`;
-                          },
-                          isSelected: group.sortAsc$.value,
-                          select: () => group.setDateSortOrder(true),
-                        }),
-                        menu.action({
-                          name: 'Newest first',
-                          label: () => {
-                            const isSelected = !group.sortAsc$.value;
-                            return html`<span
-                              style="font-size:14px;color:${isSelected
-                                ? 'var(--affine-text-emphasis-color)'
-                                : 'var(--affine-text-secondary-color)'}"
-                              >Newest first</span
-                            >`;
-                          },
-                          isSelected: !group.sortAsc$.value,
-                          select: () => group.setDateSortOrder(false),
-                        }),
-                      ],
-                    },
-                  }),
-                ],
-              }),
+                menu.group({
+                  items: [
+                    menu.dynamic(() => [
+                      menu.subMenu({
+                        name: 'Sort',
+                        openOnHover: false,
+                        middleware: dropdownSubMenuMiddleware,
+                        autoHeight: true,
+                        postfix: html`
+                          <div
+                            style="display:flex;align-items:center;gap:4px;font-size:14px;line-height:20px;color:var(--affine-text-secondary-color);margin-left:8px;"
+                          >
+                            ${group.sortAsc$.value
+                              ? 'Oldest first'
+                              : 'Newest first'}
+                          </div>
+                        `,
+                        options: {
+                          items: [
+                            menu.dynamic(() => [
+                              menu.action({
+                                name: 'Oldest first',
+                                label: () => {
+                                  const isSelected = group.sortAsc$.value;
+                                  return html`<span
+                                    style="font-size:14px;color:${isSelected
+                                      ? 'var(--affine-text-emphasis-color)'
+                                      : 'var(--affine-text-secondary-color)'}"
+                                    >Oldest first</span
+                                  >`;
+                                },
+                                isSelected: group.sortAsc$.value,
+                                select: () => group.setDateSortOrder(true),
+                              }),
+                              menu.action({
+                                name: 'Newest first',
+                                label: () => {
+                                  const isSelected = !group.sortAsc$.value;
+                                  return html`<span
+                                    style="font-size:14px;color:${isSelected
+                                      ? 'var(--affine-text-emphasis-color)'
+                                      : 'var(--affine-text-secondary-color)'}"
+                                    >Newest first</span
+                                  >`;
+                                },
+                                isSelected: !group.sortAsc$.value,
+                                select: () => group.setDateSortOrder(false),
+                              }),
+                            ]),
+                          ],
+                        },
+                      }),
+                    ]),
+                  ],
+                }),
             ]
           : []),
 

--- a/blocksuite/affine/data-view/src/core/group-by/setting.ts
+++ b/blocksuite/affine/data-view/src/core/group-by/setting.ts
@@ -423,30 +423,36 @@ export const popGroupSetting = (
                                 ['Day', 'date-day'],
                                 [
                                   'Week',
-                                  group.groupInfo$.value?.config.name === 'date-week-mon'
+                                  group.groupInfo$.value?.config.name ===
+                                  'date-week-mon'
                                     ? 'date-week-mon'
                                     : 'date-week-sun',
                                 ],
                                 ['Month', 'date-month'],
                                 ['Year', 'date-year'],
                               ] as [string, string][]
-                            ).map(([label, key]): MenuConfig =>
-                              menu.action({
-                                name: label,
-                                label: () => {
-                                  const isSelected =
-                                    group.groupInfo$.value?.config.name === key;
-                                  return html`<span
-                                    style="font-size:14px;color:${isSelected
-                                      ? 'var(--affine-text-emphasis-color)'
-                                      : 'var(--affine-text-secondary-color)'}"
-                                    >${label}</span
-                                  >`;
-                                },
-                                isSelected:
-                                  group.groupInfo$.value?.config.name === key,
-                                select: () => group.changeGroupMode(key),
-                              })
+                            ).map(
+                              ([label, key]): MenuConfig =>
+                                menu.action({
+                                  name: label,
+                                  label: () => {
+                                    const isSelected =
+                                      group.groupInfo$.value?.config.name ===
+                                      key;
+                                    return html`<span
+                                      style="font-size:14px;color:${isSelected
+                                        ? 'var(--affine-text-emphasis-color)'
+                                        : 'var(--affine-text-secondary-color)'}"
+                                      >${label}</span
+                                    >`;
+                                  },
+                                  isSelected:
+                                    group.groupInfo$.value?.config.name === key,
+                                  select: () => {
+                                    group.changeGroupMode(key);
+                                    return false;
+                                  },
+                                })
                             )
                           ),
                         ],
@@ -486,7 +492,8 @@ export const popGroupSetting = (
                                       name: label,
                                       label: () => {
                                         const isSelected =
-                                          group.groupInfo$.value?.config.name === key;
+                                          group.groupInfo$.value?.config
+                                            .name === key;
                                         return html`<span
                                           style="font-size:14px;color:${isSelected
                                             ? 'var(--affine-text-emphasis-color)'
@@ -495,8 +502,12 @@ export const popGroupSetting = (
                                         >`;
                                       },
                                       isSelected:
-                                        group.groupInfo$.value?.config.name === key,
-                                      select: () => group.changeGroupMode(key),
+                                        group.groupInfo$.value?.config.name ===
+                                        key,
+                                      select: () => {
+                                        group.changeGroupMode(key);
+                                        return false;
+                                      },
                                     })
                                   )
                                 ),
@@ -508,61 +519,67 @@ export const popGroupSetting = (
                     }),
                   ]
                 : []),
-                menu.group({
-                  items: [
-                    menu.dynamic(() => [
-                      menu.subMenu({
-                        name: 'Sort',
-                        openOnHover: false,
-                        middleware: dropdownSubMenuMiddleware,
-                        autoHeight: true,
-                        postfix: html`
-                          <div
-                            style="display:flex;align-items:center;gap:4px;font-size:14px;line-height:20px;color:var(--affine-text-secondary-color);margin-left:8px;"
-                          >
-                            ${group.sortAsc$.value
-                              ? 'Oldest first'
-                              : 'Newest first'}
-                          </div>
-                        `,
-                        options: {
-                          items: [
-                            menu.dynamic(() => [
-                              menu.action({
-                                name: 'Oldest first',
-                                label: () => {
-                                  const isSelected = group.sortAsc$.value;
-                                  return html`<span
-                                    style="font-size:14px;color:${isSelected
-                                      ? 'var(--affine-text-emphasis-color)'
-                                      : 'var(--affine-text-secondary-color)'}"
-                                    >Oldest first</span
-                                  >`;
-                                },
-                                isSelected: group.sortAsc$.value,
-                                select: () => group.setDateSortOrder(true),
-                              }),
-                              menu.action({
-                                name: 'Newest first',
-                                label: () => {
-                                  const isSelected = !group.sortAsc$.value;
-                                  return html`<span
-                                    style="font-size:14px;color:${isSelected
-                                      ? 'var(--affine-text-emphasis-color)'
-                                      : 'var(--affine-text-secondary-color)'}"
-                                    >Newest first</span
-                                  >`;
-                                },
-                                isSelected: !group.sortAsc$.value,
-                                select: () => group.setDateSortOrder(false),
-                              }),
-                            ]),
-                          ],
-                        },
-                      }),
-                    ]),
-                  ],
-                }),
+              menu.group({
+                items: [
+                  menu.dynamic(() => [
+                    menu.subMenu({
+                      name: 'Sort',
+                      openOnHover: false,
+                      middleware: dropdownSubMenuMiddleware,
+                      autoHeight: true,
+                      postfix: html`
+                        <div
+                          style="display:flex;align-items:center;gap:4px;font-size:14px;line-height:20px;color:var(--affine-text-secondary-color);margin-left:8px;"
+                        >
+                          ${group.sortAsc$.value
+                            ? 'Oldest first'
+                            : 'Newest first'}
+                        </div>
+                      `,
+                      options: {
+                        items: [
+                          menu.dynamic(() => [
+                            menu.action({
+                              name: 'Oldest first',
+                              label: () => {
+                                const isSelected = group.sortAsc$.value;
+                                return html`<span
+                                  style="font-size:14px;color:${isSelected
+                                    ? 'var(--affine-text-emphasis-color)'
+                                    : 'var(--affine-text-secondary-color)'}"
+                                  >Oldest first</span
+                                >`;
+                              },
+                              isSelected: group.sortAsc$.value,
+                              select: () => {
+                                group.setDateSortOrder(true);
+                                return false;
+                              },
+                            }),
+                            menu.action({
+                              name: 'Newest first',
+                              label: () => {
+                                const isSelected = !group.sortAsc$.value;
+                                return html`<span
+                                  style="font-size:14px;color:${isSelected
+                                    ? 'var(--affine-text-emphasis-color)'
+                                    : 'var(--affine-text-secondary-color)'}"
+                                  >Newest first</span
+                                >`;
+                              },
+                              isSelected: !group.sortAsc$.value,
+                              select: () => {
+                                group.setDateSortOrder(false);
+                                return false;
+                              },
+                            }),
+                          ]),
+                        ],
+                      },
+                    }),
+                  ]),
+                ],
+              }),
             ]
           : []),
 


### PR DESCRIPTION
## Summary
- update Date by menu to refresh selection check mark
- update Start week on menu accordingly
- update Sort menu with dynamic options

## Testing
- `yarn lint` *(fails: Couldn't find the node_modules state file)*
- `yarn test` *(fails: Couldn't find the node_modules state file)*

------
https://chatgpt.com/codex/tasks/task_e_684dee0b85548332b92e22084b47ec43