### PR TITLE
Add OS open support for attachments

### DIFF
--- a/blocksuite/affine/blocks/attachment/src/attachment-block.ts
+++ b/blocksuite/affine/blocks/attachment/src/attachment-block.ts
@@ -220,6 +220,7 @@ export class AttachmentBlockComponent extends CaptionedBlockComponent<Attachment
   override firstUpdated() {
     // lazy bindings
     this.disposables.addFromEvent(this, 'click', this.onClick);
+    this.disposables.addFromEvent(this, 'dblclick', this._handleDoubleClick);
   }
 
   protected onClick(event: MouseEvent) {
@@ -232,6 +233,11 @@ export class AttachmentBlockComponent extends CaptionedBlockComponent<Attachment
       this._selectBlock();
     }
   }
+
+  private _handleDoubleClick = (event: MouseEvent) => {
+    event.stopPropagation();
+    this.open().catch(console.error);
+  };
 
   protected renderUpgradeButton = () => {
     if (this.std.store.readonly) return null;

--- a/blocksuite/affine/blocks/attachment/src/attachment-block.ts
+++ b/blocksuite/affine/blocks/attachment/src/attachment-block.ts
@@ -114,9 +114,26 @@ export class AttachmentBlockComponent extends CaptionedBlockComponent<Attachment
     );
   };
 
-  open = () => {
+  open = async () => {
     const blobUrl = this.blobUrl;
     if (!blobUrl) return;
+
+    if (BUILD_CONFIG.isElectron && (window as any).__apis?.file?.openTempFile) {
+      try {
+        const blob = await this.resourceController.blob();
+        if (blob) {
+          const buffer = new Uint8Array(await blob.arrayBuffer());
+          await (window as any).__apis.file.openTempFile(
+            Array.from(buffer),
+            this.model.props.name
+          );
+          return;
+        }
+      } catch (err) {
+        console.error(err);
+      }
+    }
+
     window.open(blobUrl, '_blank');
   };
 

--- a/blocksuite/affine/blocks/attachment/src/attachment-block.ts
+++ b/blocksuite/affine/blocks/attachment/src/attachment-block.ts
@@ -22,6 +22,7 @@ import {
   FileSizeLimitProvider,
   TelemetryProvider,
 } from '@blocksuite/affine-shared/services';
+import { PeekViewProvider } from '@blocksuite/affine-components/peek';
 import { formatSize } from '@blocksuite/affine-shared/utils';
 import {
   AttachmentIcon,
@@ -114,7 +115,7 @@ export class AttachmentBlockComponent extends CaptionedBlockComponent<Attachment
     );
   };
 
-  open = async () => {
+  openExternal = async () => {
     const blobUrl = this.blobUrl;
     if (!blobUrl) return;
 
@@ -135,6 +136,17 @@ export class AttachmentBlockComponent extends CaptionedBlockComponent<Attachment
     }
 
     window.open(blobUrl, '_blank');
+  };
+
+  openPreview = async () => {
+    const peekView = this.std.getOptional(PeekViewProvider);
+    if (!peekView) return;
+    await peekView.peek({
+      docId: this.model.store.id,
+      blockIds: [this.blockId],
+      filetype: this.filetype,
+      target: this,
+    });
   };
 
   // Refreshes data.
@@ -236,7 +248,7 @@ export class AttachmentBlockComponent extends CaptionedBlockComponent<Attachment
 
   private _handleDoubleClick = (event: MouseEvent) => {
     event.stopPropagation();
-    this.open().catch(console.error);
+    this.openPreview().catch(console.error);
   };
 
   protected renderUpgradeButton = () => {

--- a/blocksuite/affine/blocks/attachment/src/configs/toolbar.ts
+++ b/blocksuite/affine/blocks/attachment/src/configs/toolbar.ts
@@ -24,6 +24,7 @@ import {
   DownloadIcon,
   DuplicateIcon,
   EditIcon,
+  ExpandFullIcon,
   ResetIcon,
 } from '@blocksuite/icons/lit';
 import { BlockFlavourIdentifier } from '@blocksuite/std';
@@ -151,6 +152,16 @@ export const attachmentViewDropdownMenu = {
   },
 } as const satisfies ToolbarActionGroup<ToolbarAction>;
 
+const openAction = {
+  id: 'b.open',
+  tooltip: 'Open',
+  icon: ExpandFullIcon(),
+  run(ctx) {
+    const block = ctx.getCurrentBlockByType(AttachmentBlockComponent);
+    block?.open();
+  },
+} as const satisfies ToolbarAction;
+
 const downloadAction = {
   id: 'c.download',
   tooltip: 'Download',
@@ -220,6 +231,7 @@ const builtinToolbarConfig = {
         `;
       },
     },
+    openAction,
     attachmentViewDropdownMenu,
     downloadAction,
     captionAction,
@@ -295,6 +307,7 @@ const builtinToolbarConfig = {
 const builtinSurfaceToolbarConfig = {
   actions: [
     attachmentViewDropdownMenu,
+    openAction,
     {
       id: 'c.style',
       actions: [

--- a/blocksuite/affine/blocks/attachment/src/configs/toolbar.ts
+++ b/blocksuite/affine/blocks/attachment/src/configs/toolbar.ts
@@ -165,7 +165,7 @@ const openAction = {
 
 const openExternalAction = {
   id: 'b.open-external',
-  label: 'Open externally',
+  tooltip: 'Open externally',
   icon: OpenInNewIcon(),
   run(ctx) {
     const block = ctx.getCurrentBlockByType(AttachmentBlockComponent);

--- a/blocksuite/affine/blocks/attachment/src/configs/toolbar.ts
+++ b/blocksuite/affine/blocks/attachment/src/configs/toolbar.ts
@@ -25,6 +25,7 @@ import {
   DuplicateIcon,
   EditIcon,
   ExpandFullIcon,
+  OpenInNewIcon,
   ResetIcon,
 } from '@blocksuite/icons/lit';
 import { BlockFlavourIdentifier } from '@blocksuite/std';
@@ -158,7 +159,17 @@ const openAction = {
   icon: ExpandFullIcon(),
   run(ctx) {
     const block = ctx.getCurrentBlockByType(AttachmentBlockComponent);
-    block?.open();
+    block?.openPreview();
+  },
+} as const satisfies ToolbarAction;
+
+const openExternalAction = {
+  id: 'b.open-external',
+  label: 'Open externally',
+  icon: OpenInNewIcon(),
+  run(ctx) {
+    const block = ctx.getCurrentBlockByType(AttachmentBlockComponent);
+    block?.openExternal();
   },
 } as const satisfies ToolbarAction;
 
@@ -232,6 +243,7 @@ const builtinToolbarConfig = {
       },
     },
     openAction,
+    openExternalAction,
     attachmentViewDropdownMenu,
     downloadAction,
     captionAction,
@@ -308,6 +320,7 @@ const builtinSurfaceToolbarConfig = {
   actions: [
     attachmentViewDropdownMenu,
     openAction,
+    openExternalAction,
     {
       id: 'c.style',
       actions: [

--- a/packages/frontend/apps/electron/src/helper/exposed.ts
+++ b/packages/frontend/apps/electron/src/helper/exposed.ts
@@ -2,12 +2,14 @@ import { dialogHandlers } from './dialog';
 import { dbEventsV1, dbHandlersV1, nbstoreHandlers } from './nbstore';
 import { provideExposed } from './provide';
 import { workspaceEvents, workspaceHandlers } from './workspace';
+import { fileHandlers } from './file';
 
 export const handlers = {
   db: dbHandlersV1,
   nbstore: nbstoreHandlers,
   workspace: workspaceHandlers,
   dialog: dialogHandlers,
+  file: fileHandlers,
 };
 
 export const events = {

--- a/packages/frontend/apps/electron/src/helper/file.ts
+++ b/packages/frontend/apps/electron/src/helper/file.ts
@@ -1,0 +1,24 @@
+import fs from 'fs-extra';
+import path from 'node:path';
+
+import { logger } from './logger';
+import { mainRPC } from './main-rpc';
+
+export async function openTempFile(data: number[], name: string) {
+  try {
+    const dir = await mainRPC.getPath('temp');
+    const safeName = name.replace(/[\\/?:*"<>|]/g, '_');
+    const filePath = path.join(dir, `affine-${Date.now()}-${safeName}`);
+    await fs.writeFile(filePath, Buffer.from(data));
+    await mainRPC.openPath(filePath);
+    return filePath;
+  } catch (err) {
+    logger.error('openTempFile failed', err);
+    throw err;
+  }
+}
+
+export const fileHandlers = {
+  openTempFile,
+};
+

--- a/packages/frontend/apps/electron/src/main/helper-process.ts
+++ b/packages/frontend/apps/electron/src/main/helper-process.ts
@@ -108,6 +108,7 @@ class HelperProcessManager {
     const shellMethods = pickAndBind(shell, [
       'openExternal',
       'showItemInFolder',
+      'openPath',
     ]);
     const appMethods = pickAndBind(app, ['getPath']);
 

--- a/packages/frontend/apps/electron/src/shared/type.ts
+++ b/packages/frontend/apps/electron/src/shared/type.ts
@@ -25,6 +25,7 @@ export type MainToHelper = Pick<
   | 'showSaveDialog'
   | 'openExternal'
   | 'showItemInFolder'
+  | 'openPath'
   | 'getPath'
 >;
 

--- a/packages/frontend/core/src/blocksuite/attachment-viewer/index.tsx
+++ b/packages/frontend/core/src/blocksuite/attachment-viewer/index.tsx
@@ -2,8 +2,9 @@ import { ViewBody, ViewHeader } from '@affine/core/modules/workbench';
 
 import { AttachmentFallback, AttachmentPreviewErrorBoundary } from './error';
 import { PDFViewer } from './pdf/pdf-viewer';
+import { TextViewer } from './text/text-viewer';
 import type { AttachmentViewerBaseProps, AttachmentViewerProps } from './types';
-import { buildAttachmentProps } from './utils';
+import { buildAttachmentProps, getAttachmentType } from './utils';
 import { Titlebar } from './viewer';
 import * as styles from './viewer.css';
 
@@ -36,14 +37,18 @@ export const AttachmentViewerView = ({ model }: AttachmentViewerProps) => {
 };
 
 const AttachmentViewerInner = (props: AttachmentViewerBaseProps) => {
-  const isPDF = props.model.props.type.endsWith('pdf');
+  const type = getAttachmentType(props.model);
 
-  if (isPDF) {
+  if (type === 'pdf') {
     return (
       <AttachmentPreviewErrorBoundary>
         <PDFViewer {...props} />
       </AttachmentPreviewErrorBoundary>
     );
+  }
+
+  if (type === 'text') {
+    return <TextViewer model={props.model} />;
   }
 
   return <AttachmentFallback {...props} />;

--- a/packages/frontend/core/src/blocksuite/attachment-viewer/text/text-viewer.tsx
+++ b/packages/frontend/core/src/blocksuite/attachment-viewer/text/text-viewer.tsx
@@ -1,0 +1,24 @@
+import { useEffect, useState } from 'react';
+import type { AttachmentViewerProps } from '../types';
+import { getAttachmentBlob } from '../utils';
+import * as styles from '../viewer.css';
+
+export function TextViewer({ model }: AttachmentViewerProps) {
+  const [text, setText] = useState('');
+
+  useEffect(() => {
+    (async () => {
+      const blob = await getAttachmentBlob(model);
+      if (blob) {
+        const content = await blob.text();
+        setText(content);
+      }
+    })().catch(console.error);
+  }, [model]);
+
+  return (
+    <pre className={styles.viewer} style={{ padding: '12px', whiteSpace: 'pre-wrap' }}>
+      {text}
+    </pre>
+  );
+}

--- a/packages/frontend/core/src/blocksuite/attachment-viewer/text/text-viewer.tsx
+++ b/packages/frontend/core/src/blocksuite/attachment-viewer/text/text-viewer.tsx
@@ -1,28 +1,50 @@
 import clsx from 'clsx';
 import { useEffect, useState } from 'react';
+import { getHighlighter } from 'shiki';
 import type { AttachmentViewerProps } from '../types';
 import { getAttachmentBlob } from '../utils';
 import * as styles from '../viewer.css';
 
 export function TextViewer({ model }: AttachmentViewerProps) {
-  const [text, setText] = useState('');
+  const [html, setHtml] = useState('');
 
   useEffect(() => {
     (async () => {
       const blob = await getAttachmentBlob(model);
-      if (blob) {
-        const content = await blob.text();
-        setText(content);
+      if (!blob) return;
+      const content = await blob.text();
+
+      const ext = model.props.name.split('.').pop()?.toLowerCase() ?? '';
+      let lang = 'plaintext';
+      try {
+        const { bundledLanguagesInfo } = await import('shiki');
+        const matched = bundledLanguagesInfo.find(info =>
+          [info.id, info.name, ...(info.aliases ?? [])].includes(ext)
+        );
+        if (matched) {
+          lang = matched.id;
+        }
+      } catch {
+        // ignore
       }
+
+      const highlighter = await getHighlighter({
+        themes: ['light-plus', 'dark-plus'],
+        langs: [lang],
+      });
+      const theme = document.documentElement.classList.contains('dark')
+        ? 'dark-plus'
+        : 'light-plus';
+      const highlighted = highlighter.codeToHtml(content, { lang, theme });
+      setHtml(highlighted);
     })().catch(console.error);
   }, [model]);
 
   return (
-    <pre
+    <div
       className={clsx(styles.viewer, styles.scrollable)}
       style={{ padding: '12px', whiteSpace: 'pre-wrap', wordBreak: 'break-word' }}
-    >
-      {text}
-    </pre>
+      dangerouslySetInnerHTML={{ __html: html }}
+    />
   );
 }

--- a/packages/frontend/core/src/blocksuite/attachment-viewer/text/text-viewer.tsx
+++ b/packages/frontend/core/src/blocksuite/attachment-viewer/text/text-viewer.tsx
@@ -1,3 +1,4 @@
+import clsx from 'clsx';
 import { useEffect, useState } from 'react';
 import type { AttachmentViewerProps } from '../types';
 import { getAttachmentBlob } from '../utils';
@@ -17,7 +18,10 @@ export function TextViewer({ model }: AttachmentViewerProps) {
   }, [model]);
 
   return (
-    <pre className={styles.viewer} style={{ padding: '12px', whiteSpace: 'pre-wrap' }}>
+    <pre
+      className={clsx(styles.viewer, styles.scrollable)}
+      style={{ padding: '12px', whiteSpace: 'pre-wrap', wordBreak: 'break-word' }}
+    >
       {text}
     </pre>
   );

--- a/packages/frontend/core/src/blocksuite/attachment-viewer/types.ts
+++ b/packages/frontend/core/src/blocksuite/attachment-viewer/types.ts
@@ -1,6 +1,12 @@
 import type { AttachmentBlockModel } from '@blocksuite/affine/model';
 
-export type AttachmentType = 'pdf' | 'image' | 'audio' | 'video' | 'unknown';
+export type AttachmentType =
+  | 'pdf'
+  | 'image'
+  | 'audio'
+  | 'video'
+  | 'text'
+  | 'unknown';
 
 export type AttachmentViewerProps = {
   model: AttachmentBlockModel;

--- a/packages/frontend/core/src/blocksuite/attachment-viewer/viewer.css.ts
+++ b/packages/frontend/core/src/blocksuite/attachment-viewer/viewer.css.ts
@@ -1,5 +1,5 @@
 import { cssVarV2 } from '@toeverything/theme/v2';
-import { style } from '@vanilla-extract/css';
+import { style, globalStyle } from '@vanilla-extract/css';
 
 export const viewer = style({
   position: 'relative',
@@ -31,6 +31,26 @@ export const viewer = style({
 
 export const scrollable = style({
   overflow: 'auto',
+});
+
+globalStyle(`.${scrollable}`, {
+  scrollbarGutter: 'stable',
+  scrollbarWidth: 'thin',
+  scrollbarColor: '#b1b1b1 transparent',
+});
+
+globalStyle(`.${scrollable}::-webkit-scrollbar`, {
+  width: 4,
+  height: 4,
+});
+
+globalStyle(`.${scrollable}::-webkit-scrollbar-thumb`, {
+  borderRadius: 2,
+  backgroundColor: '#b1b1b1',
+});
+
+globalStyle(`.${scrollable}::-webkit-scrollbar-corner`, {
+  display: 'none',
 });
 
 export const viewerContainer = style({

--- a/packages/frontend/core/src/blocksuite/attachment-viewer/viewer.css.ts
+++ b/packages/frontend/core/src/blocksuite/attachment-viewer/viewer.css.ts
@@ -30,7 +30,8 @@ export const viewer = style({
 });
 
 export const scrollable = style({
-  overflow: 'auto',
+  overflowY: 'auto',
+  overflowX: 'hidden',
 });
 
 globalStyle(`.${scrollable}`, {
@@ -51,6 +52,11 @@ globalStyle(`.${scrollable}::-webkit-scrollbar-thumb`, {
 
 globalStyle(`.${scrollable}::-webkit-scrollbar-corner`, {
   display: 'none',
+});
+
+globalStyle('.shiki', {
+  whiteSpace: 'pre-wrap',
+  wordBreak: 'break-word',
 });
 
 export const viewerContainer = style({

--- a/packages/frontend/core/src/blocksuite/attachment-viewer/viewer.css.ts
+++ b/packages/frontend/core/src/blocksuite/attachment-viewer/viewer.css.ts
@@ -29,6 +29,10 @@ export const viewer = style({
   },
 });
 
+export const scrollable = style({
+  overflow: 'auto',
+});
+
 export const viewerContainer = style({
   position: 'relative',
   display: 'flex',

--- a/packages/frontend/core/src/modules/media/utils.ts
+++ b/packages/frontend/core/src/modules/media/utils.ts
@@ -25,6 +25,15 @@ const videoExts = new Set([
   '3gp',
 ]);
 
+const textExts = new Set([
+  'txt',
+  'md',
+  'eml',
+  'log',
+  'json',
+  'csv',
+]);
+
 export function getAttachmentType(model: AttachmentBlockModel) {
   const type = model.props.type;
 
@@ -39,6 +48,10 @@ export function getAttachmentType(model: AttachmentBlockModel) {
 
   if (type.startsWith('video/')) {
     return 'video';
+  }
+
+  if (type.startsWith('text/') || type.startsWith('message/')) {
+    return 'text';
   }
 
   if (type === 'application/pdf') {
@@ -58,6 +71,10 @@ export function getAttachmentType(model: AttachmentBlockModel) {
 
   if (videoExts.has(ext)) {
     return 'video';
+  }
+
+  if (textExts.has(ext)) {
+    return 'text';
   }
 
   if (ext === 'pdf') {


### PR DESCRIPTION
## Summary
- add `openPath` IPC method and implement `openTempFile` helper
- expose new file handlers
- use `openTempFile` for attachments when running on Electron

## Testing
- `yarn lint` *(fails: Couldn't find the node_modules state file)*
- `yarn test` *(fails: Couldn't find the node_modules state file)*

------
https://chatgpt.com/codex/tasks/task_e_68534b2528f48332b97f233391066cef