### PR TITLE
Add validate CLI

### DIFF
--- a/package.json
+++ b/package.json
@@ -21,6 +21,8 @@
   "scripts": {
     "affine": "r affine.ts",
     "af": "r affine.ts",
+    "validate": "r validate.ts",
+    "vd": "r validate.ts",
     "dev": "yarn affine dev",
     "build": "yarn affine build",
     "lint:eslint": "cross-env NODE_OPTIONS=\"--max-old-space-size=8192\" eslint --report-unused-disable-directives-severity=off . --cache",

--- a/tools/cli/src/validate.ts
+++ b/tools/cli/src/validate.ts
@@ -1,0 +1,38 @@
+import { Workspace } from '@affine-tools/utils/workspace';
+import { Cli } from 'clipanion';
+
+import { BuildCommand } from './build';
+import { BundleCommand } from './bundle';
+import { CertCommand } from './cert';
+import { CleanCommand } from './clean';
+import type { CliContext } from './context';
+import { DevCommand } from './dev';
+import { InitCommand } from './init';
+import { RunCommand } from './run';
+
+class ValidateDevCommand extends DevCommand {
+  protected override availablePackages = Workspace.PackageNames;
+}
+
+const cli = new Cli<CliContext>({
+  binaryName: 'validate',
+  binaryVersion: '0.0.0',
+  binaryLabel: 'Validate Monorepo Tools',
+  enableColors: true,
+  enableCapture: true,
+});
+
+cli.register(RunCommand);
+cli.register(InitCommand);
+cli.register(CleanCommand);
+cli.register(BuildCommand);
+cli.register(ValidateDevCommand);
+cli.register(BundleCommand);
+cli.register(CertCommand);
+
+await cli.runExit(process.argv.slice(2), {
+  workspace: new Workspace(),
+  stdin: process.stdin,
+  stdout: process.stdout,
+  stderr: process.stderr,
+});

--- a/tools/cli/src/validate.ts
+++ b/tools/cli/src/validate.ts
@@ -1,17 +1,27 @@
-import { Workspace } from '@affine-tools/utils/workspace';
+import type { YarnWorkspaceItem } from '@affine-tools/utils/types';
+import { AliasToPackage } from '@affine-tools/utils/distribution';
+import { Workspace, type PackageName } from '@affine-tools/utils/workspace';
 import { Cli } from 'clipanion';
 
 import { BuildCommand } from './build';
-import { BundleCommand } from './bundle';
-import { CertCommand } from './cert';
 import { CleanCommand } from './clean';
 import type { CliContext } from './context';
 import { DevCommand } from './dev';
 import { InitCommand } from './init';
 import { RunCommand } from './run';
 
+const packageList: YarnWorkspaceItem[] = [
+  { name: '@validate/web', location: 'apps/web', workspaceDependencies: [] },
+  { name: '@validate/server', location: 'apps/server', workspaceDependencies: [] },
+];
+
+AliasToPackage.set('server', '@validate/server' as unknown as PackageName);
+
 class ValidateDevCommand extends DevCommand {
-  protected override availablePackages = Workspace.PackageNames;
+  protected override availablePackages: PackageName[] = [
+    '@validate/web',
+    '@validate/server',
+  ] as unknown as PackageName[];
 }
 
 const cli = new Cli<CliContext>({
@@ -27,11 +37,9 @@ cli.register(InitCommand);
 cli.register(CleanCommand);
 cli.register(BuildCommand);
 cli.register(ValidateDevCommand);
-cli.register(BundleCommand);
-cli.register(CertCommand);
 
 await cli.runExit(process.argv.slice(2), {
-  workspace: new Workspace(),
+  workspace: new Workspace(packageList as any),
   stdin: process.stdin,
   stdout: process.stdout,
   stderr: process.stderr,


### PR DESCRIPTION
## Summary
- add `validate` CLI script to allow running commands under a new binary
- expose `validate` and `vd` in root `package.json` scripts

## Testing
- `yarn install` *(fails: couldn't build packages)*

------
https://chatgpt.com/codex/tasks/task_e_685745e256f88332a5c976c940499626