### PR TITLE
Refactor cell editing hotkey handler

### DIFF
--- a/blocksuite/affine/data-view/src/view-presets/table/pc-virtual/controller/hotkeys.ts
+++ b/blocksuite/affine/data-view/src/view-presets/table/pc-virtual/controller/hotkeys.ts
@@ -3,6 +3,7 @@ import { DisposableGroup } from '@blocksuite/global/disposable';
 import type { ReactiveController } from 'lit';
 
 import { TableViewAreaSelection, TableViewRowSelection } from '../../selection';
+import type { DatabaseCellContainer } from '../row/cell.js';
 import { handleCharStartEdit } from '../../utils.js';
 import { popRowMenu } from '../row/menu';
 import type { VirtualTableViewUILogic } from '../table-view-ui-logic';
@@ -402,7 +403,7 @@ export class TableHotkeysController implements ReactiveController {
     this.disposables.add(
       this.logic.handleEvent('keyDown', ctx => {
         const event = ctx.get('keyboardState').raw;
-        return handleCharStartEdit({
+        return handleCharStartEdit<DatabaseCellContainer>({
           event,
           selection: this.selectionController.selection,
           getCellContainer: this.selectionController.getCellContainer.bind(

--- a/blocksuite/affine/data-view/src/view-presets/table/pc-virtual/controller/hotkeys.ts
+++ b/blocksuite/affine/data-view/src/view-presets/table/pc-virtual/controller/hotkeys.ts
@@ -3,6 +3,7 @@ import { DisposableGroup } from '@blocksuite/global/disposable';
 import type { ReactiveController } from 'lit';
 
 import { TableViewAreaSelection, TableViewRowSelection } from '../../selection';
+import { handleCharStartEdit } from '../../utils.js';
 import { popRowMenu } from '../row/menu';
 import type { VirtualTableViewUILogic } from '../table-view-ui-logic';
 
@@ -401,41 +402,15 @@ export class TableHotkeysController implements ReactiveController {
     this.disposables.add(
       this.logic.handleEvent('keyDown', ctx => {
         const event = ctx.get('keyboardState').raw;
-
-        const target = event.target as HTMLElement | null;
-        if (
-          target &&
-          (target.tagName === 'INPUT' || target.tagName === 'TEXTAREA')
-        ) {
-          return false;
-        }
-
-        const selection = this.selectionController.selection;
-        if (
-          selection &&
-          !TableViewRowSelection.is(selection) &&
-          !selection.isEditing &&
-          !event.metaKey &&
-          !event.ctrlKey &&
-          !event.altKey &&
-          event.key.length === 1
-        ) {
-          const cell = this.selectionController.getCellContainer(
-            selection.groupKey,
-            selection.focus.rowIndex,
-            selection.focus.columnIndex
-          );
-          if (cell) {
-            cell.column$.value?.valueSetFromString(cell.rowId, event.key);
-            this.selectionController.selection = {
-              ...selection,
-              isEditing: true,
-            };
-            event.preventDefault();
-            return true;
-          }
-        }
-        return false;
+        return handleCharStartEdit({
+          event,
+          selection: this.selectionController.selection,
+          getCellContainer: this.selectionController.getCellContainer.bind(
+            this.selectionController
+          ),
+          updateSelection: sel => (this.selectionController.selection = sel),
+          getColumn: cell => cell.column$.value,
+        });
       })
     );
   }

--- a/blocksuite/affine/data-view/src/view-presets/table/pc/controller/hotkeys.ts
+++ b/blocksuite/affine/data-view/src/view-presets/table/pc/controller/hotkeys.ts
@@ -2,6 +2,7 @@ import { popupTargetFromElement } from '@blocksuite/affine-components/context-me
 import type { ReactiveController } from 'lit';
 
 import { TableViewAreaSelection, TableViewRowSelection } from '../../selection';
+import type { TableViewCellContainer } from '../cell.js';
 import { handleCharStartEdit } from '../../utils.js';
 import { popRowMenu } from '../menu.js';
 import type { TableViewUILogic } from '../table-view-ui-logic';
@@ -400,7 +401,7 @@ export class TableHotkeysController implements ReactiveController {
     this.host?.disposables.add(
       this.logic.handleEvent('keyDown', ctx => {
         const event = ctx.get('keyboardState').raw;
-        return handleCharStartEdit({
+        return handleCharStartEdit<TableViewCellContainer>({
           event,
           selection: this.selectionController.selection,
           getCellContainer: this.selectionController.getCellContainer.bind(

--- a/blocksuite/affine/data-view/src/view-presets/table/pc/controller/hotkeys.ts
+++ b/blocksuite/affine/data-view/src/view-presets/table/pc/controller/hotkeys.ts
@@ -2,6 +2,7 @@ import { popupTargetFromElement } from '@blocksuite/affine-components/context-me
 import type { ReactiveController } from 'lit';
 
 import { TableViewAreaSelection, TableViewRowSelection } from '../../selection';
+import { handleCharStartEdit } from '../../utils.js';
 import { popRowMenu } from '../menu.js';
 import type { TableViewUILogic } from '../table-view-ui-logic';
 
@@ -399,41 +400,15 @@ export class TableHotkeysController implements ReactiveController {
     this.host?.disposables.add(
       this.logic.handleEvent('keyDown', ctx => {
         const event = ctx.get('keyboardState').raw;
-
-        const target = event.target as HTMLElement | null;
-        if (
-          target &&
-          (target.tagName === 'INPUT' || target.tagName === 'TEXTAREA')
-        ) {
-          return false;
-        }
-
-        const selection = this.selectionController.selection;
-        if (
-          selection &&
-          !TableViewRowSelection.is(selection) &&
-          !selection.isEditing &&
-          !event.metaKey &&
-          !event.ctrlKey &&
-          !event.altKey &&
-          event.key.length === 1
-        ) {
-          const cell = this.selectionController.getCellContainer(
-            selection.groupKey,
-            selection.focus.rowIndex,
-            selection.focus.columnIndex
-          );
-          if (cell) {
-            cell.column.valueSetFromString(cell.rowId, event.key);
-            this.selectionController.selection = {
-              ...selection,
-              isEditing: true,
-            };
-            event.preventDefault();
-            return true;
-          }
-        }
-        return false;
+        return handleCharStartEdit({
+          event,
+          selection: this.selectionController.selection,
+          getCellContainer: this.selectionController.getCellContainer.bind(
+            this.selectionController
+          ),
+          updateSelection: sel => (this.selectionController.selection = sel),
+          getColumn: cell => cell.column,
+        });
       })
     );
   }

--- a/blocksuite/affine/data-view/src/view-presets/table/utils.ts
+++ b/blocksuite/affine/data-view/src/view-presets/table/utils.ts
@@ -1,0 +1,58 @@
+import { TableViewRowSelection } from './selection';
+import type { TableViewSelectionWithType } from './selection';
+
+export interface TableCell {
+  rowId: string;
+}
+
+export type ColumnAccessor<T extends TableCell> = (
+  cell: T
+) => { valueSetFromString(rowId: string, value: string): void } | undefined;
+
+export interface StartEditOptions<T extends TableCell> {
+  event: KeyboardEvent;
+  selection: TableViewSelectionWithType | undefined;
+  getCellContainer: (
+    groupKey: string | undefined,
+    rowIndex: number,
+    columnIndex: number
+  ) => T | undefined;
+  updateSelection: (sel: TableViewSelectionWithType) => void;
+  getColumn: ColumnAccessor<T>;
+}
+
+export function handleCharStartEdit<T extends TableCell>(
+  options: StartEditOptions<T>
+): boolean {
+  const { event, selection, getCellContainer, updateSelection, getColumn } =
+    options;
+
+  const target = event.target as HTMLElement | null;
+  if (target && (target.tagName === 'INPUT' || target.tagName === 'TEXTAREA')) {
+    return false;
+  }
+
+  if (
+    selection &&
+    !TableViewRowSelection.is(selection) &&
+    !selection.isEditing &&
+    !event.metaKey &&
+    !event.ctrlKey &&
+    !event.altKey &&
+    event.key.length === 1
+  ) {
+    const cell = getCellContainer(
+      selection.groupKey,
+      selection.focus.rowIndex,
+      selection.focus.columnIndex
+    );
+    if (cell) {
+      const column = getColumn(cell);
+      column?.valueSetFromString(cell.rowId, event.key);
+      updateSelection({ ...selection, isEditing: true });
+      event.preventDefault();
+      return true;
+    }
+  }
+  return false;
+}


### PR DESCRIPTION
## Summary
- extract reusable hotkey handler for starting cell edit
- use the new helper in PC and virtual table controllers

## Testing
- `yarn lint` *(fails: Couldn't find the node_modules state file)*
- `yarn install` *(fails: binaries.prisma.sh blocked)*

------
https://chatgpt.com/codex/tasks/task_e_6859288999388332a1dd63843496ca74