### PR TITLE
Implement 2FA support

### DIFF
--- a/packages/backend/server/src/core/auth/controller.ts
+++ b/packages/backend/server/src/core/auth/controller.ts
@@ -43,6 +43,7 @@ interface PreflightResponse {
 interface SignInCredential {
   email: string;
   password?: string;
+  code?: string;
   callbackUrl?: string;
   client_nonce?: string;
 }
@@ -50,6 +51,7 @@ interface SignInCredential {
 interface MagicLinkCredential {
   email: string;
   token: string;
+  code?: string;
   client_nonce?: string;
 }
 
@@ -128,7 +130,8 @@ export class AuthController {
         req,
         res,
         credential.email,
-        credential.password
+        credential.password,
+        credential.code
       );
     } else {
       await this.sendMagicLink(
@@ -146,9 +149,18 @@ export class AuthController {
     req: Request,
     res: Response,
     email: string,
-    password: string
+    password: string,
+    code?: string
   ) {
     const user = await this.auth.signIn(email, password);
+
+    const settings = await this.models.userSettings.get(user.id);
+    if (settings.twoFactorEnabled) {
+      const { verifyTotp } = await import('./totp.js');
+      if (!code || !settings.twoFactorSecret || !verifyTotp(settings.twoFactorSecret, code)) {
+        throw new WrongSignInCredentials({ email });
+      }
+    }
 
     await this.auth.setCookies(req, res, user.id);
     res.status(HttpStatus.OK).send(user);
@@ -261,7 +273,7 @@ export class AuthController {
     @Req() req: Request,
     @Res() res: Response,
     @Body()
-    { email, token: otp, client_nonce: clientNonce }: MagicLinkCredential
+    { email, token: otp, client_nonce: clientNonce, code }: MagicLinkCredential
   ) {
     if (!otp || !email) {
       throw new EmailTokenNotFound();
@@ -301,6 +313,14 @@ export class AuthController {
     }
 
     const user = await this.models.user.fulfill(email);
+
+    const settings = await this.models.userSettings.get(user.id);
+    if (settings.twoFactorEnabled) {
+      const { verifyTotp } = await import('./totp.js');
+      if (!code || !settings.twoFactorSecret || !verifyTotp(settings.twoFactorSecret, code)) {
+        throw new WrongSignInCredentials({ email });
+      }
+    }
 
     await this.auth.setCookies(req, res, user.id);
     res.send({ id: user.id });

--- a/packages/backend/server/src/core/auth/totp.ts
+++ b/packages/backend/server/src/core/auth/totp.ts
@@ -1,0 +1,56 @@
+import { randomBytes, createHmac } from 'node:crypto';
+
+const alphabet = 'ABCDEFGHIJKLMNOPQRSTUVWXYZ234567';
+
+export function generateSecret(length = 32): string {
+  const bytes = randomBytes(length);
+  return Array.from(bytes, b => alphabet[b % alphabet.length]).join('');
+}
+
+function base32Decode(secret: string): Buffer {
+  const cleaned = secret.toUpperCase().replace(/=+$/, '');
+  let bits = '';
+  for (const c of cleaned) {
+    const idx = alphabet.indexOf(c);
+    if (idx === -1) {
+      throw new Error('Invalid base32 character');
+    }
+    bits += idx.toString(2).padStart(5, '0');
+  }
+  const bytes: number[] = [];
+  for (let i = 0; i + 8 <= bits.length; i += 8) {
+    bytes.push(parseInt(bits.slice(i, i + 8), 2));
+  }
+  return Buffer.from(bytes);
+}
+
+export function totp(secret: string, time = Date.now(), step = 30): string {
+  const counter = Math.floor(time / 1000 / step);
+  const buf = Buffer.alloc(8);
+  buf.writeBigUInt64BE(BigInt(counter));
+  const key = base32Decode(secret);
+  const hmac = createHmac('sha1', key).update(buf).digest();
+  const offset = hmac[hmac.length - 1] & 0xf;
+  const code =
+    ((hmac[offset] & 0x7f) << 24) |
+    ((hmac[offset + 1] & 0xff) << 16) |
+    ((hmac[offset + 2] & 0xff) << 8) |
+    (hmac[offset + 3] & 0xff);
+  const otp = code % 1_000_000;
+  return otp.toString().padStart(6, '0');
+}
+
+export function verifyTotp(
+  secret: string,
+  token: string,
+  window = 1,
+  step = 30
+): boolean {
+  token = token.replace(/\s+/g, '');
+  const now = Date.now();
+  for (let error = -window; error <= window; error++) {
+    const time = now + error * step * 1000;
+    if (totp(secret, time, step) === token) return true;
+  }
+  return false;
+}

--- a/packages/backend/server/src/core/user/resolver.ts
+++ b/packages/backend/server/src/core/user/resolver.ts
@@ -224,8 +224,11 @@ export class UserSettingsResolver {
     name: 'settings',
     description: 'Get user settings',
   })
-  async getSettings(@CurrentUser() me: CurrentUser): Promise<UserSettingsType> {
-    return await this.models.userSettings.get(me.id);
+  async getSettings(
+    @Parent() user: UserType,
+    @CurrentUser() me: CurrentUser
+  ): Promise<UserSettingsType> {
+    return await this.models.userSettings.get(user.id);
   }
 }
 
@@ -422,5 +425,36 @@ export class UserManagementResolver {
   })
   async enableUser(@Args('id') id: string): Promise<UserType> {
     return sessionUser(await this.models.user.enable(id));
+  }
+
+  @Mutation(() => String, { description: 'Generate 2FA secret for user' })
+  async adminGenerateTwoFactorSecret(@Args('userId') userId: string) {
+    const { generateSecret } = await import('../auth/totp.js');
+    const secret = generateSecret();
+    await this.models.userSettings.set(userId, { twoFactorSecret: secret });
+    return secret;
+  }
+
+  @Mutation(() => Boolean, { description: 'Enable user 2FA' })
+  async adminEnableTwoFactor(
+    @Args('userId') userId: string,
+    @Args('code') code: string
+  ) {
+    const settings = await this.models.userSettings.get(userId);
+    const { verifyTotp } = await import('../auth/totp.js');
+    if (!settings.twoFactorSecret || !verifyTotp(settings.twoFactorSecret, code)) {
+      throw new Error('Invalid two factor code');
+    }
+    await this.models.userSettings.set(userId, { twoFactorEnabled: true });
+    return true;
+  }
+
+  @Mutation(() => Boolean, { description: 'Disable user 2FA' })
+  async adminDisableTwoFactor(@Args('userId') userId: string) {
+    await this.models.userSettings.set(userId, {
+      twoFactorEnabled: false,
+      twoFactorSecret: undefined,
+    });
+    return true;
   }
 }

--- a/packages/backend/server/src/core/user/resolver.ts
+++ b/packages/backend/server/src/core/user/resolver.ts
@@ -176,6 +176,50 @@ export class UserSettingsResolver {
     return true;
   }
 
+  @Mutation(() => String, {
+    name: 'generateTwoFactorSecret',
+    description: 'Generate two factor secret',
+  })
+  async generateTwoFactorSecret(@CurrentUser() user: CurrentUser) {
+    const { generateSecret } = await import('../auth/totp.js');
+    const secret = generateSecret();
+    await this.models.userSettings.set(user.id, {
+      twoFactorSecret: secret,
+    });
+    return secret;
+  }
+
+  @Mutation(() => Boolean, {
+    name: 'enableTwoFactor',
+    description: 'Enable two factor authentication',
+  })
+  async enableTwoFactor(
+    @CurrentUser() user: CurrentUser,
+    @Args('code') code: string
+  ) {
+    const settings = await this.models.userSettings.get(user.id);
+    const { verifyTotp } = await import('../auth/totp.js');
+    if (!settings.twoFactorSecret || !verifyTotp(settings.twoFactorSecret, code)) {
+      throw new Error('Invalid two factor code');
+    }
+    await this.models.userSettings.set(user.id, {
+      twoFactorEnabled: true,
+    });
+    return true;
+  }
+
+  @Mutation(() => Boolean, {
+    name: 'disableTwoFactor',
+    description: 'Disable two factor authentication',
+  })
+  async disableTwoFactor(@CurrentUser() user: CurrentUser) {
+    await this.models.userSettings.set(user.id, {
+      twoFactorEnabled: false,
+      twoFactorSecret: undefined,
+    });
+    return true;
+  }
+
   @ResolveField(() => UserSettingsType, {
     name: 'settings',
     description: 'Get user settings',

--- a/packages/backend/server/src/core/user/types.ts
+++ b/packages/backend/server/src/core/user/types.ts
@@ -121,6 +121,9 @@ export class UserSettingsType implements UserSettings {
 
   @Field({ description: 'Receive mention email' })
   receiveMentionEmail!: boolean;
+
+  @Field({ description: 'Enable two factor authentication' })
+  twoFactorEnabled!: boolean;
 }
 
 @InputType()
@@ -145,4 +148,7 @@ export class UpdateUserSettingsInput implements UserSettingsInput {
 
   @Field({ description: 'Receive mention email', nullable: true })
   receiveMentionEmail?: boolean;
+
+  @Field({ description: 'Enable two factor authentication', nullable: true })
+  twoFactorEnabled?: boolean;
 }

--- a/packages/backend/server/src/models/user-settings.ts
+++ b/packages/backend/server/src/models/user-settings.ts
@@ -7,6 +7,8 @@ import { BaseModel } from './base';
 export const UserSettingsSchema = z.object({
   receiveInvitationEmail: z.boolean().default(true),
   receiveMentionEmail: z.boolean().default(true),
+  twoFactorEnabled: z.boolean().default(false),
+  twoFactorSecret: z.string().optional(),
 });
 
 export type UserSettingsInput = z.input<typeof UserSettingsSchema>;

--- a/packages/backend/server/src/schema.gql
+++ b/packages/backend/server/src/schema.gql
@@ -1133,6 +1133,15 @@ type Mutation {
   """Reenable an banned user"""
   enableUser(id: String!): UserType!
 
+  """Generate 2FA secret for user"""
+  adminGenerateTwoFactorSecret(userId: String!): String!
+
+  """Enable user 2FA"""
+  adminEnableTwoFactor(userId: String!, code: String!): Boolean!
+
+  """Disable user 2FA"""
+  adminDisableTwoFactor(userId: String!): Boolean!
+
   """Create a chat session"""
   forkCopilotSession(options: ForkChatSessionInput!): String!
   generateLicenseKey(sessionId: String!): String!

--- a/packages/backend/server/src/schema.gql
+++ b/packages/backend/server/src/schema.gql
@@ -1205,6 +1205,9 @@ type Mutation {
 
   """Update user settings"""
   updateSettings(input: UpdateUserSettingsInput!): Boolean!
+  generateTwoFactorSecret: String!
+  enableTwoFactor(code: String!): Boolean!
+  disableTwoFactor: Boolean!
   updateSubscriptionRecurring(idempotencyKey: String @deprecated(reason: "use header `Idempotency-Key`"), plan: SubscriptionPlan = Pro, recurring: SubscriptionRecurring!, workspaceId: String): SubscriptionType!
 
   """Update an user"""
@@ -1812,6 +1815,9 @@ input UpdateUserSettingsInput {
 
   """Receive mention email"""
   receiveMentionEmail: Boolean
+
+  """Enable two factor authentication"""
+  twoFactorEnabled: Boolean
 }
 
 input UpdateWorkspaceInput {
@@ -1872,6 +1878,9 @@ type UserSettingsType {
 
   """Receive mention email"""
   receiveMentionEmail: Boolean!
+
+  """Enable two factor authentication"""
+  twoFactorEnabled: Boolean!
 }
 
 type UserType {

--- a/packages/common/graphql/src/graphql/get-user-settings.gql
+++ b/packages/common/graphql/src/graphql/get-user-settings.gql
@@ -3,6 +3,7 @@ query getUserSettings {
     settings {
       receiveInvitationEmail
       receiveMentionEmail
+      twoFactorEnabled
     }
   }
 }

--- a/packages/common/graphql/src/graphql/index.ts
+++ b/packages/common/graphql/src/graphql/index.ts
@@ -203,6 +203,9 @@ export const listUsersQuery = {
     hasPassword
     emailVerified
     avatarUrl
+    settings {
+      twoFactorEnabled
+    }
   }
   usersCount
 }`,
@@ -235,6 +238,30 @@ export const updateAccountMutation = {
     name
     email
   }
+}`,
+};
+
+export const adminGenerateTwoFactorSecretMutation = {
+  id: 'adminGenerateTwoFactorSecretMutation' as const,
+  op: 'adminGenerateTwoFactorSecret',
+  query: `mutation adminGenerateTwoFactorSecret($userId: String!) {
+  adminGenerateTwoFactorSecret(userId: $userId)
+}`,
+};
+
+export const adminEnableTwoFactorMutation = {
+  id: 'adminEnableTwoFactorMutation' as const,
+  op: 'adminEnableTwoFactor',
+  query: `mutation adminEnableTwoFactor($userId: String!, $code: String!) {
+  adminEnableTwoFactor(userId: $userId, code: $code)
+}`,
+};
+
+export const adminDisableTwoFactorMutation = {
+  id: 'adminDisableTwoFactorMutation' as const,
+  op: 'adminDisableTwoFactor',
+  query: `mutation adminDisableTwoFactor($userId: String!) {
+  adminDisableTwoFactor(userId: $userId)
 }`,
 };
 

--- a/packages/common/graphql/src/graphql/index.ts
+++ b/packages/common/graphql/src/graphql/index.ts
@@ -1225,6 +1225,7 @@ export const getUserSettingsQuery = {
     settings {
       receiveInvitationEmail
       receiveMentionEmail
+      twoFactorEnabled
     }
   }
 }`,

--- a/packages/common/graphql/src/schema.ts
+++ b/packages/common/graphql/src/schema.ts
@@ -2930,6 +2930,7 @@ export type ListUsersQuery = {
     hasPassword: boolean | null;
     emailVerified: boolean;
     avatarUrl: string | null;
+    settings: { __typename?: 'UserSettingsType'; twoFactorEnabled: boolean };
   }>;
 };
 
@@ -2970,6 +2971,34 @@ export type UpdateAccountMutation = {
     name: string;
     email: string;
   };
+};
+
+export type AdminGenerateTwoFactorSecretMutationVariables = Exact<{
+  userId: Scalars['String']['input'];
+}>;
+
+export type AdminGenerateTwoFactorSecretMutation = {
+  __typename?: 'Mutation';
+  adminGenerateTwoFactorSecret: string;
+};
+
+export type AdminEnableTwoFactorMutationVariables = Exact<{
+  userId: Scalars['String']['input'];
+  code: Scalars['String']['input'];
+}>;
+
+export type AdminEnableTwoFactorMutation = {
+  __typename?: 'Mutation';
+  adminEnableTwoFactor: boolean;
+};
+
+export type AdminDisableTwoFactorMutationVariables = Exact<{
+  userId: Scalars['String']['input'];
+}>;
+
+export type AdminDisableTwoFactorMutation = {
+  __typename?: 'Mutation';
+  adminDisableTwoFactor: boolean;
 };
 
 export type UpdateAppConfigMutationVariables = Exact<{
@@ -5495,6 +5524,21 @@ export type Mutations =
       name: 'updateAccountMutation';
       variables: UpdateAccountMutationVariables;
       response: UpdateAccountMutation;
+    }
+  | {
+      name: 'adminGenerateTwoFactorSecretMutation';
+      variables: AdminGenerateTwoFactorSecretMutationVariables;
+      response: AdminGenerateTwoFactorSecretMutation;
+    }
+  | {
+      name: 'adminEnableTwoFactorMutation';
+      variables: AdminEnableTwoFactorMutationVariables;
+      response: AdminEnableTwoFactorMutation;
+    }
+  | {
+      name: 'adminDisableTwoFactorMutation';
+      variables: AdminDisableTwoFactorMutationVariables;
+      response: AdminDisableTwoFactorMutation;
     }
   | {
       name: 'updateAppConfigMutation';

--- a/packages/common/graphql/src/schema.ts
+++ b/packages/common/graphql/src/schema.ts
@@ -2387,6 +2387,8 @@ export interface UpdateUserSettingsInput {
   receiveInvitationEmail?: InputMaybe<Scalars['Boolean']['input']>;
   /** Receive mention email */
   receiveMentionEmail?: InputMaybe<Scalars['Boolean']['input']>;
+  /** Enable two factor authentication */
+  twoFactorEnabled?: InputMaybe<Scalars['Boolean']['input']>;
 }
 
 export interface UpdateWorkspaceInput {
@@ -2446,6 +2448,8 @@ export interface UserSettingsType {
   receiveInvitationEmail: Scalars['Boolean']['output'];
   /** Receive mention email */
   receiveMentionEmail: Scalars['Boolean']['output'];
+  /** Enable two factor authentication */
+  twoFactorEnabled: Scalars['Boolean']['output'];
 }
 
 export interface UserType {
@@ -4144,6 +4148,7 @@ export type GetUserSettingsQuery = {
       __typename?: 'UserSettingsType';
       receiveInvitationEmail: boolean;
       receiveMentionEmail: boolean;
+      twoFactorEnabled: boolean;
     };
   } | null;
 };

--- a/packages/frontend/admin/src/modules/accounts/components/data-table-row-actions.tsx
+++ b/packages/frontend/admin/src/modules/accounts/components/data-table-row-actions.tsx
@@ -27,6 +27,9 @@ import {
   useDeleteUser,
   useDisableUser,
   useEnableUser,
+  useGenerateTwoFactorSecret,
+  useEnableTwoFactor,
+  useDisableTwoFactor,
   useResetUserPassword,
 } from './use-user-management';
 import { UpdateUserForm } from './user-form';
@@ -46,6 +49,9 @@ export function DataTableRowActions({ user }: DataTableRowActionsProps) {
   const deleteUser = useDeleteUser();
   const disableUser = useDisableUser();
   const enableUser = useEnableUser();
+  const generateSecret = useGenerateTwoFactorSecret();
+  const enableTwoFactor = useEnableTwoFactor();
+  const disableTwoFactor = useDisableTwoFactor();
   const { resetPasswordLink, onResetPassword } = useResetUserPassword();
 
   const openResetPasswordDialog = useCallback(() => {
@@ -96,6 +102,26 @@ export function DataTableRowActions({ user }: DataTableRowActionsProps) {
   const handleEnable = useCallback(() => {
     enableUser(user.id, handleEnabling);
   }, [enableUser, handleEnabling, user.id]);
+
+  const handleEnable2FA = useCallback(() => {
+    generateSecret({ userId: user.id })
+      .then(async res => {
+        const secret = res.adminGenerateTwoFactorSecret;
+        const code = window.prompt(
+          `Secret: ${secret}\nEnter code from authenticator:`
+        );
+        if (!code) return;
+        await enableTwoFactor({ userId: user.id, code });
+        toast('Two factor enabled');
+      })
+      .catch(e => toast.error('Failed to enable 2FA: ' + e.message));
+  }, [generateSecret, enableTwoFactor, user.id]);
+
+  const handleDisable2FA = useCallback(() => {
+    disableTwoFactor({ userId: user.id })
+      .then(() => toast('Two factor disabled'))
+      .catch(e => toast.error('Failed to disable 2FA: ' + e.message));
+  }, [disableTwoFactor, user.id]);
 
   const openDeleteDialog = useCallback(() => {
     setDeleteDialogOpen(true);
@@ -184,6 +210,21 @@ export function DataTableRowActions({ user }: DataTableRowActionsProps) {
             <LockIcon fontSize={20} />
             {user.hasPassword ? 'Reset Password' : 'Setup Account'}
           </DropdownMenuItem>
+          {user.settings?.twoFactorEnabled ? (
+            <DropdownMenuItem
+              className="px-2 py-[6px] text-sm font-normal gap-2 cursor-pointer"
+              onSelect={handleDisable2FA}
+            >
+              Disable 2FA
+            </DropdownMenuItem>
+          ) : (
+            <DropdownMenuItem
+              className="px-2 py-[6px] text-sm font-normal gap-2 cursor-pointer"
+              onSelect={handleEnable2FA}
+            >
+              Enable 2FA
+            </DropdownMenuItem>
+          )}
           {user.disabled && (
             <DropdownMenuItem
               className="px-2 py-[6px] text-sm font-normal gap-2 cursor-pointer"

--- a/packages/frontend/admin/src/modules/accounts/components/use-user-management.ts
+++ b/packages/frontend/admin/src/modules/accounts/components/use-user-management.ts
@@ -15,6 +15,9 @@ import {
   listUsersQuery,
   updateAccountFeaturesMutation,
   updateAccountMutation,
+  adminGenerateTwoFactorSecretMutation,
+  adminEnableTwoFactorMutation,
+  adminDisableTwoFactorMutation,
 } from '@affine/graphql';
 import { useCallback, useMemo, useState } from 'react';
 import { toast } from 'sonner';
@@ -221,6 +224,27 @@ export const useDisableUser = () => {
   );
 
   return disableById;
+};
+
+export const useGenerateTwoFactorSecret = () => {
+  const { trigger } = useMutation({
+    mutation: adminGenerateTwoFactorSecretMutation,
+  });
+  return trigger;
+};
+
+export const useEnableTwoFactor = () => {
+  const { trigger } = useMutation({
+    mutation: adminEnableTwoFactorMutation,
+  });
+  return trigger;
+};
+
+export const useDisableTwoFactor = () => {
+  const { trigger } = useMutation({
+    mutation: adminDisableTwoFactorMutation,
+  });
+  return trigger;
 };
 
 export const useImportUsers = () => {

--- a/packages/frontend/admin/src/modules/accounts/use-user-list.ts
+++ b/packages/frontend/admin/src/modules/accounts/use-user-list.ts
@@ -1,22 +1,26 @@
 import { useQuery } from '@affine/admin/use-query';
 import { listUsersQuery } from '@affine/graphql';
-import { useState } from 'react';
+import { useMemo, useState } from 'react';
 
 export const useUserList = () => {
   const [pagination, setPagination] = useState({
     pageIndex: 0,
     pageSize: 10,
   });
-  const {
-    data: { users, usersCount },
-  } = useQuery({
-    query: listUsersQuery,
-    variables: {
+  const variables = useMemo(
+    () => ({
       filter: {
         first: pagination.pageSize,
         skip: pagination.pageIndex * pagination.pageSize,
       },
-    },
+    }),
+    [pagination]
+  );
+  const {
+    data: { users, usersCount },
+  } = useQuery({
+    query: listUsersQuery,
+    variables,
   });
 
   return {

--- a/packages/frontend/apps/ios/App/Packages/AffineGraphQL/Sources/Operations/Queries/GetUserSettingsQuery.graphql.swift
+++ b/packages/frontend/apps/ios/App/Packages/AffineGraphQL/Sources/Operations/Queries/GetUserSettingsQuery.graphql.swift
@@ -7,7 +7,7 @@ public class GetUserSettingsQuery: GraphQLQuery {
   public static let operationName: String = "getUserSettings"
   public static let operationDocument: ApolloAPI.OperationDocument = .init(
     definition: .init(
-      #"query getUserSettings { currentUser { __typename settings { __typename receiveInvitationEmail receiveMentionEmail } } }"#
+      #"query getUserSettings { currentUser { __typename settings { __typename receiveInvitationEmail receiveMentionEmail twoFactorEnabled } } }"#
     ))
 
   public init() {}
@@ -52,12 +52,16 @@ public class GetUserSettingsQuery: GraphQLQuery {
           .field("__typename", String.self),
           .field("receiveInvitationEmail", Bool.self),
           .field("receiveMentionEmail", Bool.self),
+          .field("twoFactorEnabled", Bool.self),
         ] }
 
         /// Receive invitation email
         public var receiveInvitationEmail: Bool { __data["receiveInvitationEmail"] }
         /// Receive mention email
         public var receiveMentionEmail: Bool { __data["receiveMentionEmail"] }
+
+        /// Enable two factor authentication
+        public var twoFactorEnabled: Bool { __data["twoFactorEnabled"] }
       }
     }
   }

--- a/packages/frontend/apps/ios/App/Packages/AffineGraphQL/Sources/Schema/InputObjects/UpdateUserSettingsInput.graphql.swift
+++ b/packages/frontend/apps/ios/App/Packages/AffineGraphQL/Sources/Schema/InputObjects/UpdateUserSettingsInput.graphql.swift
@@ -12,11 +12,13 @@ public struct UpdateUserSettingsInput: InputObject {
 
   public init(
     receiveInvitationEmail: GraphQLNullable<Bool> = nil,
-    receiveMentionEmail: GraphQLNullable<Bool> = nil
+    receiveMentionEmail: GraphQLNullable<Bool> = nil,
+    twoFactorEnabled: GraphQLNullable<Bool> = nil
   ) {
     __data = InputDict([
       "receiveInvitationEmail": receiveInvitationEmail,
-      "receiveMentionEmail": receiveMentionEmail
+      "receiveMentionEmail": receiveMentionEmail,
+      "twoFactorEnabled": twoFactorEnabled
     ])
   }
 
@@ -30,5 +32,11 @@ public struct UpdateUserSettingsInput: InputObject {
   public var receiveMentionEmail: GraphQLNullable<Bool> {
     get { __data["receiveMentionEmail"] }
     set { __data["receiveMentionEmail"] = newValue }
+  }
+
+  /// Enable two factor authentication
+  public var twoFactorEnabled: GraphQLNullable<Bool> {
+    get { __data["twoFactorEnabled"] }
+    set { __data["twoFactorEnabled"] = newValue }
   }
 }


### PR DESCRIPTION
## Summary
- add TOTP utilities
- expand user settings to keep two factor info
- expose two factor state in GraphQL schema and queries
- add mutations to manage two factor settings
- verify TOTP codes during sign in

## Testing
- `yarn test` *(fails: Couldn't find the node_modules state file)*

------
https://chatgpt.com/codex/tasks/task_e_685f8049de248332977394544a933922