### PR TITLE
Implement basic 2FA support

### DIFF
--- a/packages/backend/server/migrations/20250703000000_add_two_factor/migration.sql
+++ b/packages/backend/server/migrations/20250703000000_add_two_factor/migration.sql
@@ -1,0 +1,2 @@
+-- AlterTable
+ALTER TABLE "users" ADD COLUMN "two_factor_secret" VARCHAR;

--- a/packages/backend/server/package.json
+++ b/packages/backend/server/package.json
@@ -118,7 +118,8 @@
     "typescript": "^5.7.2",
     "winston": "^3.17.0",
     "yjs": "^13.6.21",
-    "zod": "^3.24.1"
+    "zod": "^3.24.1",
+    "otplib": "^12.0.1"
   },
   "devDependencies": {
     "@affine-tools/cli": "workspace:*",

--- a/packages/backend/server/schema.prisma
+++ b/packages/backend/server/schema.prisma
@@ -20,6 +20,7 @@ model User {
   createdAt       DateTime  @default(now()) @map("created_at") @db.Timestamptz(3)
   /// Not available if user signed up through OAuth providers
   password        String?   @db.VarChar
+  twoFactorSecret String?   @map("two_factor_secret") @db.VarChar
   /// Indicate whether the user finished the signup progress.
   /// for example, the value will be false if user never registered and invited into a workspace by others.
   registered      Boolean   @default(true)

--- a/packages/backend/server/src/base/helpers/crypto.ts
+++ b/packages/backend/server/src/base/helpers/crypto.ts
@@ -12,6 +12,7 @@ import {
 } from 'node:crypto';
 
 import { Injectable, Logger, OnModuleInit } from '@nestjs/common';
+import { authenticator } from 'otplib';
 import {
   hash as hashPassword,
   verify as verifyPassword,
@@ -183,6 +184,18 @@ export class CryptoHelper implements OnModuleInit {
     }
 
     return otp;
+  }
+
+  generateTotpSecret() {
+    return authenticator.generateSecret();
+  }
+
+  verifyTotp(token: string, secret: string) {
+    try {
+      return authenticator.check(token, secret);
+    } catch {
+      return false;
+    }
   }
 
   sha256(data: string) {

--- a/packages/backend/server/src/core/auth/config.ts
+++ b/packages/backend/server/src/core/auth/config.ts
@@ -10,6 +10,7 @@ export interface AuthConfig {
   allowSignup: boolean;
   requireEmailDomainVerification: boolean;
   requireEmailVerification: boolean;
+  twoFactorEnabled: boolean;
   passwordRequirements: ConfigItem<{
     min: number;
     max: number;
@@ -34,6 +35,10 @@ defineModuleConfig('auth', {
   requireEmailVerification: {
     desc: 'Whether require email verification before accessing restricted resources(not implemented).',
     default: true,
+  },
+  twoFactorEnabled: {
+    desc: 'Enable two factor authentication for password sign in.',
+    default: false,
   },
   passwordRequirements: {
     desc: 'The password strength requirements when set new password.',

--- a/packages/backend/server/src/core/auth/controller.ts
+++ b/packages/backend/server/src/core/auth/controller.ts
@@ -43,6 +43,7 @@ interface PreflightResponse {
 interface SignInCredential {
   email: string;
   password?: string;
+  totp?: string;
   callbackUrl?: string;
   client_nonce?: string;
 }
@@ -128,7 +129,8 @@ export class AuthController {
         req,
         res,
         credential.email,
-        credential.password
+        credential.password,
+        credential.totp
       );
     } else {
       await this.sendMagicLink(
@@ -146,9 +148,19 @@ export class AuthController {
     req: Request,
     res: Response,
     email: string,
-    password: string
+    password: string,
+    totp?: string
   ) {
     const user = await this.auth.signIn(email, password);
+
+    if (
+      this.config.auth.twoFactorEnabled &&
+      user.twoFactorSecret
+    ) {
+      if (!totp || !this.auth.verifyTotp(totp, user.twoFactorSecret)) {
+        throw new WrongSignInCredentials({ email });
+      }
+    }
 
     await this.auth.setCookies(req, res, user.id);
     res.status(HttpStatus.OK).send(user);

--- a/packages/backend/server/src/core/auth/service.ts
+++ b/packages/backend/server/src/core/auth/service.ts
@@ -19,6 +19,7 @@ export function sessionUser(
   return assign(pick(user, 'id', 'email', 'avatarUrl', 'name', 'disabled'), {
     hasPassword: user.password !== null,
     emailVerified: user.emailVerifiedAt !== null,
+    twoFactorEnabled: !!user.twoFactorSecret,
   });
 }
 
@@ -47,6 +48,14 @@ export class AuthService implements OnApplicationBootstrap {
     private readonly mailer: Mailer,
     private readonly feature: FeatureService
   ) {}
+
+  generateTotpSecret() {
+    return this.crypto.generateTotpSecret();
+  }
+
+  verifyTotp(token: string, secret: string) {
+    return this.crypto.verifyTotp(token, secret);
+  }
 
   async onApplicationBootstrap() {
     if (env.dev) {

--- a/packages/backend/server/src/core/auth/session.ts
+++ b/packages/backend/server/src/core/auth/session.ts
@@ -48,6 +48,7 @@ export interface CurrentUser
   extends Pick<User, 'id' | 'email' | 'avatarUrl' | 'name' | 'disabled'> {
   hasPassword: boolean | null;
   emailVerified: boolean;
+  twoFactorEnabled: boolean;
 }
 
 // interface and variable don't conflict

--- a/packages/backend/server/src/core/user/index.ts
+++ b/packages/backend/server/src/core/user/index.ts
@@ -1,7 +1,8 @@
-import { Module } from '@nestjs/common';
+import { Module, forwardRef } from '@nestjs/common';
 
 import { PermissionModule } from '../permission';
 import { StorageModule } from '../storage';
+import { AuthModule } from '../auth';
 import { UserAvatarController } from './controller';
 import {
   UserManagementResolver,
@@ -10,7 +11,7 @@ import {
 } from './resolver';
 
 @Module({
-  imports: [StorageModule, PermissionModule],
+  imports: [StorageModule, PermissionModule, forwardRef(() => AuthModule)],
   providers: [UserResolver, UserManagementResolver, UserSettingsResolver],
   controllers: [UserAvatarController],
 })

--- a/packages/backend/server/src/core/user/resolver.ts
+++ b/packages/backend/server/src/core/user/resolver.ts
@@ -22,7 +22,8 @@ import {
 } from '../../base';
 import { Models, UserSettingsSchema } from '../../models';
 import { Public } from '../auth/guard';
-import { sessionUser } from '../auth/service';
+import { sessionUser, AuthService } from '../auth/service';
+import { Inject, forwardRef } from '@nestjs/common';
 import { CurrentUser } from '../auth/session';
 import { Admin } from '../common';
 import { AvatarStorage } from '../storage';
@@ -43,7 +44,8 @@ import {
 export class UserResolver {
   constructor(
     private readonly storage: AvatarStorage,
-    private readonly models: Models
+    private readonly models: Models,
+    @Inject(forwardRef(() => AuthService)) private readonly auth: AuthService
   ) {}
 
   @Throttle('strict')
@@ -135,6 +137,19 @@ export class UserResolver {
     }
 
     return sessionUser(await this.models.user.update(user.id, input));
+  }
+
+  @Mutation(() => String)
+  async enableTwoFactor(@CurrentUser() user: CurrentUser) {
+    const secret = this.auth.generateTotpSecret();
+    await this.models.user.update(user.id, { twoFactorSecret: secret });
+    return secret;
+  }
+
+  @Mutation(() => Boolean)
+  async disableTwoFactor(@CurrentUser() user: CurrentUser) {
+    await this.models.user.update(user.id, { twoFactorSecret: null });
+    return true;
   }
 
   @Mutation(() => RemoveAvatar, {

--- a/packages/backend/server/src/core/user/types.ts
+++ b/packages/backend/server/src/core/user/types.ts
@@ -40,6 +40,11 @@ export class UserType implements CurrentUser {
   })
   hasPassword!: boolean | null;
 
+  @Field(() => Boolean, {
+    description: 'Two factor authentication enabled',
+  })
+  twoFactorEnabled!: boolean;
+
   @Field(() => Date, {
     deprecationReason: 'useless',
     description: 'User email verified',

--- a/packages/backend/server/src/models/user.ts
+++ b/packages/backend/server/src/models/user.ts
@@ -114,7 +114,7 @@ export class UserModel extends BaseModel {
     filter: UserFilter = {}
   ): Promise<User | null> {
     const rows = await this.db.$queryRaw<User[]>`
-      SELECT id, name, email, password, registered, email_verified as "emailVerifiedAt", avatar_url as "avatarUrl", registered, created_at as "createdAt", disabled
+      SELECT id, name, email, password, two_factor_secret as "twoFactorSecret", registered, email_verified as "emailVerifiedAt", avatar_url as "avatarUrl", registered, created_at as "createdAt", disabled
       FROM "users"
       WHERE lower("email") = lower(${email})
       ${Prisma.raw(filter.withDisabled ? '' : 'AND disabled = false')}

--- a/packages/frontend/admin/src/config.json
+++ b/packages/frontend/admin/src/config.json
@@ -71,6 +71,10 @@
       "type": "Boolean",
       "desc": "Whether require email verification before accessing restricted resources(not implemented)."
     },
+    "twoFactorEnabled": {
+      "type": "Boolean",
+      "desc": "Enable two factor authentication for password sign in."
+    },
     "passwordRequirements": {
       "type": "Object",
       "desc": "The password strength requirements when set new password."


### PR DESCRIPTION
## Summary
- add optional two factor auth secret on users and migration
- expose 2FA toggle in auth config and admin UI
- implement totp generation/verification in crypto helper
- require totp on password login when 2FA is enabled
- allow users to enable/disable 2FA via GraphQL

## Testing
- `yarn lint packages/backend/server/src/core/auth/service.ts` *(fails: Couldn't find the node_modules state file)*

------
https://chatgpt.com/codex/tasks/task_e_685fa0cf5e548332a12ff68d4d3e7083